### PR TITLE
Update to add latest missing kernel redirects

### DIFF
--- a/ntoskrn8.c
+++ b/ntoskrn8.c
@@ -164,6 +164,8 @@ KeFlushQueuedDpcs_k8 (void)    // WinXP RTM, SP1
 }
 
 
+
+
 NTSTATUS
 RtlQueryRegistryValuesEx_k8 (
     ULONG                       RelativeTo,
@@ -2478,6 +2480,35 @@ SeQueryInformationToken_inject (                                // wine
     }
 }
 
+
+NTSTATUS
+IoSynchronousCallDriver_k8 (
+    PDEVICE_OBJECT DeviceObject,
+    PIRP Irp )
+{
+	/* PSEUDO CODE
+    unsigned int local_0x18; // [esp-24]
+    unsigned char local_0x14[20]; // [esp-20]
+    unsigned long v1; // eax
+    local_0x18 = (unsigned char)&local_0x18 & 0xFFFFFF00;
+    local_0x14[0] = 0;
+    local_0x18 = 1024;
+    local_0x14[8] = &local_0x18[2];
+    local_0x14[4] = &local_0x18[2];
+    *(*(Irp + 96) + 4294967292) = &local_0x18;
+    *(*(Irp + 96) + 4294967288) = &CmpCompleteFlushAndPurgeIrp;
+    *(*(Irp + 96) + 4294967263) = 224;
+    v1 = IofCallDriver( DeviceObject, Irp );
+    if( v1 == 259 ) {
+        KeWaitForSingleObject( &local_0x18, 5, 0, 0, 0 );
+        v1 = *(Irp + 24);
+	}
+    return v1;
+*/ 
+	return IofCallDriver( DeviceObject, Irp );
+
+//return STATUS_SUCCESS;
+}
 
 
 

--- a/ntoskrnl_redirects.h
+++ b/ntoskrnl_redirects.h
@@ -6919,6 +6919,20 @@ bypass(ZwWaitForMultipleObjects)
 bypass(ZwWaitForSingleObject)
 bypass(ZwWriteFile)
 bypass(ZwYieldExecution)
+
+// added missing exports according to ntoskrnl.exe v6.0.6003.21442 
+
+bypass(FsRtlInitializeExtraCreateParameter)
+bypass(FsRtlInitializeExtraCreateParameterList)
+bypass(FsRtlPrepareToReuseEcp)
+bypass(FsRtlRegisterUncProviderEx2)
+bypass(IoRegisterFsRegistrationChangeMountAware)
+bypass(KeConnectInterruptForHal)
+bypass(KeFlushCurrentTbImmediately)
+bypass(PsDereferenceKernelStack)
+bypass(PsReferenceKernelStack)
+bypass(RtlIsSandboxedToken)
+
 #endif //    Vista x32 ntoskrnl export
 
 
@@ -8812,6 +8826,20 @@ bypass(ZwWaitForMultipleObjects)
 bypass(ZwWaitForSingleObject)
 bypass(ZwWriteFile)
 bypass(ZwYieldExecution)
+
+// added missing exports according to ntoskrnl.exe v6.0.6003.21442 
+
+bypass(FsRtlInitializeExtraCreateParameter)
+bypass(FsRtlInitializeExtraCreateParameterList)
+bypass(FsRtlPrepareToReuseEcp)
+bypass(FsRtlRegisterUncProviderEx2)
+bypass(IoRegisterFsRegistrationChangeMountAware)
+bypass(KeConnectInterruptForHal)
+bypass(KiMcaExceptionHandlerWrapper)
+bypass(PsDereferenceKernelStack)
+bypass(PsReferenceKernelStack)
+bypass(RtlIsSandboxedToken)
+
 #endif //    Vista x64 ntoskrnl export
 
 
@@ -8904,6 +8932,7 @@ k8_win7(    PcwRegister,                        8)
 k8_win7(    PcwUnregister,                      4)
 k8_win7(    PoEndDeviceBusy,                    4)
 k8_win7(    PoStartDeviceBusy,                  4)
+
 
 #endif  // < Win7 x32/x64 Extender
 
@@ -11102,6 +11131,23 @@ bypass(ZwWaitForMultipleObjects)
 bypass(ZwWaitForSingleObject)
 bypass(ZwWriteFile)
 bypass(ZwYieldExecution)
+
+
+// added missing exports according to ntoskrnl.exe v6.1.7601.25920
+
+bypass(EtwSetInformation)
+bypass(FsRtlPrepareToReuseEcp)
+bypass(FsRtlRegisterUncProviderEx2)
+bypass(IoEnumerateRegisteredFiltersListEx)
+bypass(IoRegisterFsRegistrationChangeMountAwareEx)
+bypass(KeConnectInterruptForHal)
+bypass(KiMcaExceptionHandlerWrapper)
+bypass(PsDereferenceKernelStack)
+bypass(PsReferenceKernelStack)
+bypass(RtlIsSandboxedToken)
+bypass(SeGetLogonSessionToken)
+
+
 #endif //    Win7 x32 ntoskrnl export
 
 
@@ -13221,6 +13267,24 @@ bypass(ZwWaitForMultipleObjects)
 bypass(ZwWaitForSingleObject)
 bypass(ZwWriteFile)
 bypass(ZwYieldExecution)
+
+
+// added missing exports according to ntoskrnl.exe v6.1.7601.25920
+
+
+bypass(EtwSetInformation)
+bypass(FsRtlPrepareToReuseEcp)
+bypass(FsRtlRegisterUncProviderEx2)
+bypass(IoEnumerateRegisteredFiltersListEx)
+bypass(IoRegisterFsRegistrationChangeMountAwareEx)
+bypass(KeConnectInterruptForHal)
+bypass(KeFlushCurrentTbImmediately)
+bypass(PsDereferenceKernelStack)
+bypass(PsReferenceKernelStack)
+bypass(RtlIsSandboxedToken)
+bypass(SeGetLogonSessionToken)
+
+
 #endif //    Win7 x64 ntoskrnl export
 
 
@@ -13237,6 +13301,7 @@ k8_win8(    MmAllocateContiguousNodeMemory,     36)
 k8_win8(    RtlCheckPortableOperatingSystem,    4)
 k8_win8(    RtlQueryRegistryValuesEx,           20)
 k8_win8(    RtlSetPortableOperatingSystem,      4)
+k8_win8(   	IoSynchronousCallDriver,			8)
 
 #endif  // < Win8 x32/x64 Extender
 


### PR DESCRIPTION
Hi,

I have updated project with missing kernel redirects for Vista and 7 targets from latest available ntoskrnl.exe. I have also added new export IoSynchronousCallDriver